### PR TITLE
resolve nvim_fzf_directory when needed

### DIFF
--- a/lua/fzf/actions.lua
+++ b/lua/fzf/actions.lua
@@ -1,13 +1,12 @@
 local registry = require("fzf.registry")
 
-local nvim_fzf_directory = vim.g.nvim_fzf_directory
-local shell_script_path = string.format("%s/action_helper.sh", nvim_fzf_directory)
-
 local function escape(str)
   return vim.fn.shellescape(str)
 end
 
 local function raw_action(fn)
+  local nvim_fzf_directory = vim.g.nvim_fzf_directory
+  local shell_script_path = string.format("%s/action_helper.sh", nvim_fzf_directory)
   local id = registry.register_func(fn)
   local action_string = string.format("%s %s %s {+}",
     escape(shell_script_path), escape(nvim_fzf_directory), id)


### PR DESCRIPTION
The lua part of the plugin might get loaded first, in which case the local `nvim_fzf_directory` variable would be nil.
Moving this inside the `raw_action` function makes sure its resolved correctly