### PR TITLE
allow the user to set different fzf binary

### DIFF
--- a/lua/fzf.lua
+++ b/lua/fzf.lua
@@ -39,7 +39,7 @@ function FZF.raw_fzf(contents, fzf_cli_args)
   if not coroutine.running() then
     error("Please run function in a coroutine")
   end
-  local command = "fzf"
+  local command = FZF.fzf_binary or "fzf"
   local fifotmpname = vim.fn.tempname()
   local outputtmpname = vim.fn.tempname()
 

--- a/lua/fzf.lua
+++ b/lua/fzf.lua
@@ -200,11 +200,14 @@ function FZF.fzf(contents, user_opts, window_options)
   local opts = process_options(user_opts, window_options)
 
   local win = vim.api.nvim_get_current_win()
-  local buf = float.create(opts.window_options)
+  local bufnr, winid = float.create(opts.window_options)
 
   local results = FZF.raw_fzf(contents, opts)
-  vim.cmd("wincmd q")
-  vim.api.nvim_buf_delete(buf, {force=true})
+  vim.api.nvim_buf_delete(bufnr, {force=true})
+  if vim.api.nvim_win_is_valid(winid) then
+    vim.api.nvim_set_current_win(winid)
+    vim.cmd("wincmd q")
+  end
   vim.api.nvim_set_current_win(win)
   return results
 end

--- a/lua/fzf.lua
+++ b/lua/fzf.lua
@@ -206,7 +206,7 @@ function FZF.fzf(contents, user_opts, window_options)
   vim.api.nvim_buf_delete(bufnr, {force=true})
   if vim.api.nvim_win_is_valid(winid) then
     vim.api.nvim_set_current_win(winid)
-    vim.cmd("wincmd q")
+    vim.api.nvim_win_close(winid, {force=true})
   end
   vim.api.nvim_set_current_win(win)
   return results

--- a/lua/fzf.lua
+++ b/lua/fzf.lua
@@ -203,12 +203,15 @@ function FZF.fzf(contents, user_opts, window_options)
   local bufnr, winid = float.create(opts.window_options)
 
   local results = FZF.raw_fzf(contents, opts)
-  vim.api.nvim_buf_delete(bufnr, {force=true})
   if vim.api.nvim_win_is_valid(winid) then
-    vim.api.nvim_set_current_win(winid)
     vim.api.nvim_win_close(winid, {force=true})
   end
-  vim.api.nvim_set_current_win(win)
+  if vim.api.nvim_buf_is_valid(bufnr) then
+    vim.api.nvim_buf_delete(bufnr, {force=true})
+  end
+  if vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_set_current_win(win)
+  end
   return results
 end
 

--- a/lua/fzf.lua
+++ b/lua/fzf.lua
@@ -44,7 +44,7 @@ function FZF.raw_fzf(contents, fzf_cli_args)
   local outputtmpname = vim.fn.tempname()
 
   if contents then
-    if type(contents) == "string" then
+    if type(contents) == "string" and #contents>0 then
       command = string.format("%s | %s", contents, command)
     else
       command = command .. " < " .. vim.fn.shellescape(fifotmpname)
@@ -62,7 +62,7 @@ function FZF.raw_fzf(contents, fzf_cli_args)
   local done_state = false
 
   local function on_done()
-    if type(contents) == "string" then
+    if not contents or type(contents) == "string" then
       return
     end
     if done_state then return end
@@ -90,7 +90,7 @@ function FZF.raw_fzf(contents, fzf_cli_args)
   vim.cmd[[startinsert]]
 
 
-  if type(contents) == "string" then
+  if not contents or type(contents) == "string" then
     goto wait_for_fzf
   end
 

--- a/lua/fzf.lua
+++ b/lua/fzf.lua
@@ -203,7 +203,7 @@ function FZF.fzf(contents, user_opts, window_options)
   local buf = float.create(opts.window_options)
 
   local results = FZF.raw_fzf(contents, opts)
-  vim.cmd("bw! " .. buf)
+  vim.api.nvim_buf_delete(buf, {force=true})
   vim.api.nvim_set_current_win(win)
   return results
 end

--- a/lua/fzf.lua
+++ b/lua/fzf.lua
@@ -203,6 +203,7 @@ function FZF.fzf(contents, user_opts, window_options)
   local buf = float.create(opts.window_options)
 
   local results = FZF.raw_fzf(contents, opts)
+  vim.cmd("wincmd q")
   vim.api.nvim_buf_delete(buf, {force=true})
   vim.api.nvim_set_current_win(win)
   return results

--- a/lua/fzf/floating_window.lua
+++ b/lua/fzf/floating_window.lua
@@ -20,13 +20,13 @@ function M.create(opts)
   win_opts.col = opts.col or math.floor((columns - win_opts.width) / 2)
 
   local bufnr = vim.api.nvim_create_buf(false, true)
-  vim.api.nvim_open_win(bufnr, true, win_opts)
+  local winid = vim.api.nvim_open_win(bufnr, true, win_opts)
 
   if opts.window_on_create then
     opts.window_on_create()
   end
 
-  return bufnr
+  return bufnr, winid
 end
 
 return M


### PR DESCRIPTION
This allows to set a custom `fzf_binary`, I did this mostly to be able test [skim](https://github.com/lotabout/skim) instead of `fzf`, works great, pretty much all options are compatible aside from the `change:reload` which skim implements with `-i` (interactive) mode.