### PR TITLE
finer control on action|raw_action filespec

### DIFF
--- a/action_helper.sh
+++ b/action_helper.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-#1 directory to cd to
-#2 registry id of the function to run
-#3.. the fzf choices
-cd "$1"
-nvim --headless --clean --cmd "luafile ./action_helper.lua" "$@"

--- a/lua/fzf/actions.lua
+++ b/lua/fzf/actions.lua
@@ -6,17 +6,18 @@ local function escape(str)
   return vim.fn.shellescape(str)
 end
 
-function M.raw_action(fn)
+function M.raw_action(fn, filespec)
   local nvim_fzf_directory = vim.g.nvim_fzf_directory
-  local shell_script_path = string.format("%s/action_helper.sh", nvim_fzf_directory)
   local id = registry.register_func(fn)
-  local action_string = string.format("%s %s %s {+}",
-    escape(shell_script_path), escape(nvim_fzf_directory), id)
+  local action_string = string.format("nvim --headless --clean --cmd %s %s %s %s",
+    vim.fn.shellescape("luafile " .. nvim_fzf_directory .. "/action_helper.lua"),
+    vim.fn.shellescape(nvim_fzf_directory),
+    id, filespec or "{+}")
   return action_string, id
 end
 
-function M.action(fn)
-  local action_string, id = M.raw_action(fn)
+function M.action(fn, filespec)
+  local action_string, id = M.raw_action(fn, filespec)
   return escape(action_string), id
 end
 


### PR DESCRIPTION
This helps avoid bugs when sending output lines from `rg` which contain special chars, for example if your rg output matches a line with say \`text\`, and since the entire line (`{+}`) is sent to `action_helper.sh` the action might fail as it tries to execute what's inside the back-ticks, I couldn't solve it consistently  with `vim.fn.shellescape` and I find this solution better as it gives you more flexibility combined with sending `--delimiter` to `fzf`.