### PR TITLE
Improve performance of cmd_line_transformer

### DIFF
--- a/lua/fzf/helpers.lua
+++ b/lua/fzf/helpers.lua
@@ -1,10 +1,13 @@
 local uv = vim.loop
 local fzf_async_action = require("fzf.actions").async_action
 
+-- save to upvalue for performance reasons
+local string_byte = string.byte
+local string_sub = string.sub
+
 local function find_last_newline(str)
-  local byte = string.byte
   for i=#str,1,-1 do
-    if byte(str, i) == 10 then
+    if string_byte(str, i) == 10 then
         return i
     end
   end
@@ -86,16 +89,16 @@ local function cmd_line_transformer(opts, fn)
 
         n_writing = n_writing + 1
 
-        if string.byte(data, #data) == 10 then
-            local stripped_without_newline = string.sub(data, 1, #data - 1) 
+        if string_byte(data, #data) == 10 then
+            local stripped_without_newline = string_sub(data, 1, #data - 1) 
             fzf_cb(process_lines(stripped_without_newline, fn), on_write_callback)
         else
             local nl_index = find_last_newline(data)
             if not nl_index then
                 prev_line_content = data
             else
-                prev_line_content = string.sub(data, nl_index + 1)
-                local stripped_without_newline = string.sub(data, 1, nl_index - 1)
+                prev_line_content = string_sub(data, nl_index + 1)
+                local stripped_without_newline = string_sub(data, 1, nl_index - 1)
                 fzf_cb(process_lines(stripped_without_newline, fn), on_write_callback)
             end
         end

--- a/lua/fzf/helpers.lua
+++ b/lua/fzf/helpers.lua
@@ -2,20 +2,16 @@ local uv = vim.loop
 local fzf_async_action = require("fzf.actions").async_action
 
 local function find_last_newline(str)
+  local byte = string.byte
   for i=#str,1,-1 do
-    if string.byte(str, i) == 10 then
+    if byte(str, i) == 10 then
         return i
     end
   end
 end
 
 local function process_lines(str, fn)
-  local t = {}
-  local lines = vim.split(str, "\n")
-  for idx, val in ipairs(lines) do
-      t[idx] = fn(val)
-  end
-  return table.concat(t, "\n")
+  return string.gsub(str, '[^\n]+', fn)
 end
 
 -- takes either a string, or a table with properties


### PR DESCRIPTION
process_lines() doesn't need to split the input on newlines, save the
resulting lines in a table, and then create a new table with transformed
lines only to concatenate them again at the end. It can simply pass the
transform function to gsub() with a pattern matching everything except
new lines.

I've been on a mission recently to improve the performance of fzf-lua and nvim-fzf. This particular change was low hanging fruit for an easy performance bump.