### PR TITLE
raw_fzf to return process exit_code

### DIFF
--- a/lua/fzf.lua
+++ b/lua/fzf.lua
@@ -128,7 +128,7 @@ function FZF.raw_fzf(contents, fzf_cli_args, user_options)
   local co = coroutine.running()
   vim.fn.termopen(command, {
     cwd = cwd,
-    on_exit = function()
+    on_exit = function(_, exit_code, _)
       local f = io.open(outputtmpname)
       local output = get_lines_from_file(f)
       f:close()
@@ -145,7 +145,7 @@ function FZF.raw_fzf(contents, fzf_cli_args, user_options)
       else
         ret = output
       end
-      coroutine.resume(co, ret)
+      coroutine.resume(co, ret, exit_code)
     end
   })
   vim.cmd[[set ft=fzf]]


### PR DESCRIPTION
This change helps better error detection when fzf fails with an error, `fzf` could fail for many different reasons, user specifying wrong flags, old versions of fzf that doesn't support certain flags, etc.

I didn't know if you'd like this code to also be returned from `FZF.fzf` and `FZF.provided_win_fzf`, up to you.
