### PR TITLE
added cb function to return pid from 'cmd_line_transformer'

### DIFF
--- a/lua/fzf/helpers.lua
+++ b/lua/fzf/helpers.lua
@@ -52,7 +52,7 @@ local function cmd_line_transformer(opts, fn)
         stdout:close()
       end)
 
-      if opts.pid_cb and type(opts.pid_cb) == 'function' then
+      if opts.pid_cb then
         opts.pid_cb(pid)
       end
 


### PR DESCRIPTION
As per the discussion in [fzf-lua#187](https://github.com/ibhagwan/fzf-lua/issues/187).