### PR TITLE
cmd_line_transformer: check for nil data when concatenating previous line

### DIFF
--- a/lua/fzf/helpers.lua
+++ b/lua/fzf/helpers.lua
@@ -78,7 +78,7 @@ local function cmd_line_transformer(opts, fn)
       -- a line
       local function read_callback(err, data)
         if err then return end
-        if prev_line_content then
+        if data and prev_line_content then
             data = prev_line_content .. data
             prev_line_content = nil
         end


### PR DESCRIPTION
Prevents attempting to concatenate `nil` which can happen when the process is terminated prematurely (i.e. `kill`)