### PR TITLE
shell action helper nvim 0.8 compatibility

### DIFF
--- a/action_helper.lua
+++ b/action_helper.lua
@@ -32,40 +32,45 @@ uv.listen(preview_socket, 100, function(err)
 end)
 
 
-local function_id = tonumber(vim.fn.argv(1))
-local success, errmsg = pcall(function ()
-  local nargs = vim.fn.argc()
-  local args = {}
-  -- this is guaranteed to be 2 or more, we are interested in those greater than 2
-  for i=3,nargs do
-    -- vim uses zero indexing
-    table.insert(args, vim.fn.argv(i - 1))
-  end
-  local environ = vim.fn.environ()
-  local chan_id = vim.fn.sockconnect("pipe", vim.fn.argv(0), { rpc = true })
-  -- for skim compatibility
-  local preview_lines = environ.FZF_PREVIEW_LINES or environ.LINES
-  local preview_cols = environ.FZF_PREVIEW_COLUMNS or environ.COLUMNS
-  vim.rpcrequest(chan_id, "nvim_exec_lua", [[
-    local luaargs = {...}
-    local function_id = luaargs[1]
-    local preview_socket_path = luaargs[2]
-    local fzf_selection = luaargs[3]
-    local fzf_lines = luaargs[4]
-    local fzf_columns = luaargs[5]
-    local usr_func = require"fzf.registry".get_func(function_id)
-    return usr_func(preview_socket_path, fzf_selection, fzf_lines, fzf_columns)
-  ]], {
-    function_id,
-    preview_socket_path,
-    args,
-    tonumber(preview_lines),
-    tonumber(preview_cols)
-  })
-  vim.fn.chanclose(chan_id)
-end)
+local function rpc_nvim_exec_lua(opts)
+  local success, errmsg = pcall(function ()
+    local nargs = vim.fn.argc()
+    local args = {}
+    -- fzf field expression unpacks from the argument list
+    for i=1,nargs do
+      -- vim uses zero indexing
+      table.insert(args, vim.fn.argv(i - 1))
+    end
+    local environ = vim.fn.environ()
+    local chan_id = vim.fn.sockconnect("pipe", opts.action_server, { rpc = true })
+    -- for skim compatibility
+    local preview_lines = environ.FZF_PREVIEW_LINES or environ.LINES
+    local preview_cols = environ.FZF_PREVIEW_COLUMNS or environ.COLUMNS
+    vim.rpcrequest(chan_id, "nvim_exec_lua", [[
+      local luaargs = {...}
+      local function_id = luaargs[1]
+      local preview_socket_path = luaargs[2]
+      local fzf_selection = luaargs[3]
+      local fzf_lines = luaargs[4]
+      local fzf_columns = luaargs[5]
+      local usr_func = require"fzf.registry".get_func(function_id)
+      return usr_func(preview_socket_path, fzf_selection, fzf_lines, fzf_columns)
+    ]], {
+      opts.function_id,
+      preview_socket_path,
+      args,
+      tonumber(preview_lines),
+      tonumber(preview_cols)
+    })
+    vim.fn.chanclose(chan_id)
+  end)
 
-if not success then
-  io.write("NVIM-FZF LUA ERROR\n\n" .. errmsg .. "\n")
-  vim.cmd [[qall]]
+  if not success then
+    io.write("NVIM-FZF LUA ERROR\n\n" .. errmsg .. "\n")
+    vim.cmd [[qall]]
+  end
 end
+
+return {
+  rpc_nvim_exec_lua = rpc_nvim_exec_lua
+}

--- a/lua/fzf/actions.lua
+++ b/lua/fzf/actions.lua
@@ -42,12 +42,15 @@ function M.raw_async_action(fn, fzf_field_expression)
   -- 'nvim', it can be something else
   local nvim_command = vim.v.argv[1]
 
-  local action_string = string.format("%s --headless --clean --cmd %s %s %s %s",
+  local call_args = ("action_server=[[%s]], function_id=%d"):format(
+    action_server_address, id)
+
+  local action_string = string.format("%s -n --headless --clean --cmd %s %s",
     vim.fn.shellescape(nvim_command),
-    vim.fn.shellescape("luafile " .. nvim_fzf_directory .. "/action_helper.lua"),
-    vim.fn.shellescape(action_server_address),
-    id,
+    vim.fn.shellescape(("lua loadfile([[%s]])().rpc_nvim_exec_lua({%s})")
+      :format(nvim_fzf_directory .. "/action_helper.lua", call_args)),
     fzf_field_expression)
+
   return action_string, id
 end
 


### PR DESCRIPTION
Not sure what changed with neovim `0.8` but it causes shell actions to print an additional error to stderr.

Run the below code with the nightly:
```lua
local fzf = require("fzf").fzf
local raw_action = require("fzf.actions").raw_action

local raw_act_string = raw_action(function(args)
  return "selected: ".. args[1]
end)

coroutine.wrap(function()
  fzf({1, 2, 3, 4}, "--preview-window=nohidden --preview " ..
    vim.fn.shellescape(raw_act_string))
end)()
```

And you will see an additional error message in the preview as such:
![image](https://user-images.githubusercontent.com/59988195/168953875-71afe9b2-5b17-4453-97df-1bdd5edc9008.png)

This is actually the`action_server_address` (our RPC server), the reason for this error is the way the shell helper works by utilizing slots 1-2 in the arglist for the server address and function ID, with neovim `0.8` it will attempt to open the temp pipe and fail thus printing the error in the screenshot.

I recently solved this in fzf-lua (https://github.com/ibhagwan/fzf-lua/issues/409) so I figured I'd save you a couple of hours of banging your head against neovim :-)

This PR changes the way the shell helper command is structured, instead of using `luafile` it uses `lua loadfile(<file>)().fnc(<args>) {fzf_field_expression}`, this way neovim never attempts to open the RPC pipe and fails.