### PR TITLE
Add space after colorscheme command in colorscheme picker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ coroutine.wrap(function ()
   if not choices then
     vim.cmd("colorscheme " .. current_colorscheme)
   else
-    vim.cmd("colorscheme" .. choices[1])
+    vim.cmd("colorscheme " .. choices[1])
   end
 end)()
 


### PR DESCRIPTION
There needs to be a space after "colorscheme " in the vim.cmd; this bug is mostly unnoticeable because the same colorscheme is already set by the preview function. But when I tried to modify your example to add some additional commands afterwards, they weren't running.