### PR TITLE
nvim binary: use 'vim.v.progpath' instead of 'vim.v.argv[1]'

### DIFF
--- a/lua/fzf/actions.lua
+++ b/lua/fzf/actions.lua
@@ -55,7 +55,7 @@ function M.raw_async_action(fn, fzf_field_expression)
 
   -- this is for windows WSL and AppImage users, their nvim path isn't just
   -- 'nvim', it can be something else
-  local nvim_command = vim.v.argv[1]
+  local nvim_command = vim.v.progpath
 
   local call_arg_table_string = ("{ action_server=%s, function_id=%d }"):format(
      lua_escape(action_server_address), id)


### PR DESCRIPTION
When the user opens neovim using a relative path and then uses `:cd` to change the working directory the neovim binary path (used in the shell helper) will be have the wrong path and fail to run.

I encountered this in fzf-lua when using the nightly binary tar and opening neovim with `./nvim/...` after using `cd` once the path provided by `vim.v.argv[1]` no longer works.

Using `v:progpath` is safer and always provides the full path of the neovim binary.