### PR TITLE
feat: add support for window titles

### DIFF
--- a/lua/fzf/floating_window.lua
+++ b/lua/fzf/floating_window.lua
@@ -19,6 +19,12 @@ function M.create(opts)
   win_opts.row = opts.row or math.floor(((lines - win_opts.height) / 2) - 1)
   win_opts.col = opts.col or math.floor((columns - win_opts.width) / 2)
 
+  --Floating window title
+  if opts.title then
+    win_opts.title = opts.title
+    win_opts.title_pos = opts.title or 'center'
+  end
+
   local bufnr = vim.api.nvim_create_buf(false, true)
   local winid = vim.api.nvim_open_win(bufnr, true, win_opts)
 


### PR DESCRIPTION
This PR allows users to include the `title` and `title_pos` options in the `options` table that is passed to `fzf.fzf(contents, [fzf_cli_args], [options])` function, effectively setting the title of the floating window created as a result of that call. 

After this PR: 


https://github.com/vijaymarupudi/nvim-fzf/assets/69449791/8ead38e7-0ad9-46a8-bdab-b3a851d1d120

