### PR TITLE
Wrap fzf command to always go through cmd on windows

### DIFF
--- a/lua/fzf.lua
+++ b/lua/fzf.lua
@@ -198,7 +198,9 @@ function FZFObject:run()
   local termopen_first_arg
 
   if is_windows then
-    termopen_first_arg = self.command
+    -- for compatibility reasons, run this command in `cmd`. This is because
+    -- PowerShell does not support the `<` operator that some fzf commands use.
+    termopen_first_arg = {"cmd", "/c", self.command}
   else
     -- for performance reasons, run this command in `sh`. This is because the
     -- default shells of some users take a long time to launch, and this


### PR DESCRIPTION
Background: A few people (including me) use the settings in `:h shell-powershell` to change their default shell to be pwsh/powershell. This causes errors when opening the terminal with `<` in the final fzf command.

From very barebones testing this patch seems to work, but let me know whether this breaks something on your end.

For those using `cmd` by default it may also be worth looking into whether to check `'shell'` before wrapping the command, but I think `cmd` launches pretty fast on most systems.