### PR TITLE
Start insert mode on stdout

### DIFF
--- a/lua/fzf.lua
+++ b/lua/fzf.lua
@@ -194,7 +194,7 @@ function FZFObject:run()
     vim.fn.system({"mkfifo", self.fifotmpname})
   end
 
- 
+
   local termopen_first_arg
 
   if is_windows then
@@ -290,7 +290,7 @@ function FZF.raw_fzf(contents, fzf_cli_args, user_options)
   local fzf_obj = FZFObject:new(contents, fzf_cli_args, user_options, function(ret, exit_code)
     coroutine.resume(co, ret, exit_code)
   end)
-  
+
   fzf_obj:run()
   return coroutine.yield()
 end

--- a/lua/fzf.lua
+++ b/lua/fzf.lua
@@ -1,6 +1,8 @@
 local uv = vim.loop
 local float = require('fzf.floating_window')
 local WriteQueue = require("fzf.utils").WriteQueue
+local nvim_get_current_buf = vim.api.nvim_get_current_buf
+local nvim_get_mode = vim.api.nvim_get_mode
 
 local FZF = {}
 
@@ -221,16 +223,22 @@ function FZFObject:run()
     }
   end
 
+  local bufnr = nvim_get_current_buf()
+
   vim.fn.termopen(termopen_first_arg, {
     cwd = self.cwd,
     env = env,
     on_exit = function(_, exit_code, _)
       self:cleanup({exit_code = exit_code})
-    end
+    end,
+    on_stdout = function()
+      if bufnr == nvim_get_current_buf() and nvim_get_mode().mode ~= "t" then
+        vim.cmd[[startinsert]]
+      end
+    end,
   })
 
   vim.cmd[[set ft=fzf]]
-  vim.cmd[[startinsert]]
 
   if not self.contents or type(self.contents) == "string" then
     return
@@ -299,7 +307,7 @@ end
 function FZF.provided_win_fzf(contents, fzf_cli_args, options)
   local win = vim.api.nvim_get_current_win()
   local output, exit_code = FZF.raw_fzf(contents, fzf_cli_args, options)
-  local buf = vim.api.nvim_get_current_buf()
+  local buf = nvim_get_current_buf()
   vim.api.nvim_win_close(win, true)
   vim.api.nvim_buf_delete(buf, { force = true })
   return output, exit_code


### PR DESCRIPTION
When `vim.ui.select` is invoked to decide what to do with nvim-fzf's choice, but nvim-fzf is also used as `vim.ui.select`'s backend, a simple call to `startinsert` does not have the intended effect, and we are left on `nt` mode (Normal in terminal-emulator).

The solution was to invoke `startinsert` from within the `on_stdout` callback.

This following script reproduces the issue.

<details>
<summary>ui-select.lua</summary>

```lua
local concat = table.concat
local shellescape = vim.fn.shellescape

local dir = vim.fn.expand("<sfile>:p:h")
vim.opt.packpath:append(dir)

vim.cmd.packadd("nvim-fzf")

vim.api.nvim_create_user_command("Files", function()
  coroutine.wrap(function()
    local selected = require("fzf").fzf("find . -type f -printf '%P\n' | tail +2")
    vim.ui.select(
      {
         "Bad" ,
         "OK" ,
         "Really good" ,
         "Great" ,
         "Amazing" ,
      },
      {
        prompt = string.format("What is %s to you?", selected[1]),
      },
      function(choice)
        print(choice .. "!")
      end
    )
  end)()
end, { nargs = 0 })

function ui_select(items, ui_opts, on_choice)
  local entries = {}
  for i, e in ipairs(items) do
    table.insert(
      entries,
      ("%d. %s"):format(
        i,
        ui_opts.format_item and ui_opts.format_item(e) or tostring(e)
      )
    )
  end

  local prompt = ui_opts.prompt or "Select one of> "
  local fzf_cli_args = concat({ "--prompt=", shellescape(prompt) })

  local function select()
    local selected = require("fzf").fzf(entries, fzf_cli_args)

    if not selected then return end

    local idx = tonumber(selected[1]:match("%d+"))
    on_choice(items[idx])
  end

  local co = coroutine.running()

  if co then
    select()
  else
    coroutine.wrap(function()
      select()
    end)()
  end
end

vim.ui.select = ui_select
```

</details>

Run it with `nvim --clean -u ui-select.lua`.